### PR TITLE
Restore intl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.4
+
+- Updated `intl` dependency to version `>=0.19 <0.21.0`, fixing resolve issue for flutter.
+
 ## 1.0.3
 
 - Improved package description.
@@ -22,7 +26,7 @@
 - Added `toZonedDateTime()` extension for `DateTime`.
 - Modified `LocalDate.from(Temporal)` to use `ChronoField.epochDay` instead of components.
 - Modified `LocalTime.from(Temporal)` to use `ChronoField.microsecondOfDay` instead of components.
-- Updated `intl` dependency to version `1.20.1`.
+- Updated `intl` dependency to version `0.20.1`.
 - Improved documentation coverage.
 
 ## 1.0.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ^3.6.0
 
 dependencies:
-  intl: ^0.20.1
+  intl: ">=0.19.0 <0.21.0"
 
 dev_dependencies:
   test: ^1.25.12


### PR DESCRIPTION
Due to pinned packages in flutter, the recent upgrade of the `intl` package has made the package unusable.

Restore support for version 0.19.0 by widening to `>=0.19.0 <0.21.0` so both the flutter version and the latest version are supported.