### PR TITLE
Fix end-of-month calculation error.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.5
+
+- Fixed a bug where `Temporal.atEndOfMonth()` would return a wrong result
+  for dates near the end of the month, ironically.
+
 ## 1.0.4
 
 - Updated `intl` dependency to version `>=0.19 <0.21.0`, fixing resolve issue for flutter.

--- a/lib/src/temporal/temporal.dart
+++ b/lib/src/temporal/temporal.dart
@@ -58,7 +58,8 @@ extension TemporalAdjusters<T extends Temporal> on T {
   /// print(date.atEndOfMonth()) // 2024-10-31
   /// ```
   T atEndOfMonth() {
-    var plusMonth = this.plus(1, ChronoUnit.months);
+    var startOfMonth = this.atStartOfMonth(); // Prevent jumping two months
+    var plusMonth = startOfMonth.plus(1, ChronoUnit.months);
     var newVal = plusMonth.adjust(ChronoField.dayOfMonth, 0);
     return newVal as T;
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: date_n_time
 description: "Dart Package for working with Dates without Times and/or Zones."
-version: 1.0.4
+version: 1.0.5
 repository: https://github.com/CoalBuster/date_n_time
 
 environment:


### PR DESCRIPTION
# Bug Report

**Situation:**
LocalDate(2024, 10, 31).atEndOfMonth();

**Expected outcome:**
2024-10-31

**Actual outcome:**
2024-11-30

**Cause:**
This is because the current implementation add 1 month, then adjusts day to 0.
For most cases, this works fine.
However, when adding a month results in an invalid date, it rolls over another month, breaking with expectations.
In the example above, 2024-11-31 does not exist, and thus is rolled to 2024-12-01 instead.
Therefore, this edge case is mostly found around the end of a month, days 28-31.

**Fix:**
First jump to the start of this month. This will make sure adding 1 month always ends up at the first of next month, after we can safely subtract 1 day.