### PR TITLE
LocalDateRange Enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.6
+
+- Added `period` property for `LocalDateRange`.
+- Modified `LocalDateRange` constructor to allow for zero-length ranges.
+
 ## 1.0.5
 
 - Fixed a bug where `Temporal.atEndOfMonth()` would return a wrong result

--- a/lib/src/local_date_range.dart
+++ b/lib/src/local_date_range.dart
@@ -1,4 +1,5 @@
 import 'local_date.dart';
+import 'period.dart';
 import 'temporal/chrono_unit.dart';
 
 class LocalDateRange {
@@ -9,9 +10,9 @@ class LocalDateRange {
   final LocalDate end;
 
   /// Creates a date range for the given start and end [DateTime].
-  LocalDateRange(this.start, this.end) : assert(start < end);
+  LocalDateRange(this.start, this.end) : assert(start >= end);
 
-  // Period get period => start.until(end);
+  Period get period => start == end ? Period.zero : Period.between(start, end);
 
   @override
   bool operator ==(Object other) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: date_n_time
 description: "Dart Package for working with Dates without Times and/or Zones."
-version: 1.0.5
+version: 1.0.6
 repository: https://github.com/CoalBuster/date_n_time
 
 environment:


### PR DESCRIPTION
- Add `period` property for `LocalDateRange`.
- Modify `LocalDateRange` constructor to allow for zero-length ranges.